### PR TITLE
Fix CI/CD to fail when Holesky verification fails

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -76,7 +76,7 @@ jobs:
             --watch \
             ${{ steps.deploy.outputs.contract_address }} \
             src/HackathonVoting.sol:HackathonVoting \
-            --etherscan-api-key $ETHERSCAN_API_KEY || echo "Verification failed or contract already verified"
+            --etherscan-api-key $ETHERSCAN_API_KEY
 
       - name: Register test projects and vote
         id: test_projects

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -65,10 +65,13 @@ jobs:
 
       - name: Verify contract
         if: ${{ github.event.inputs.verify != 'false' }}
+        continue-on-error: true
         env:
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: |
           echo "Verifying HackathonVoting contract on Etherscan..."
+          echo "Waiting 30 seconds for transaction to propagate..."
+          sleep 30
 
           forge verify-contract \
             --chain-id 17000 \

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -65,7 +65,6 @@ jobs:
 
       - name: Verify contract
         if: ${{ github.event.inputs.verify != 'false' }}
-        continue-on-error: true
         env:
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: |


### PR DESCRIPTION
## Summary
- Removed the `|| echo` fallback that was preventing the verification step from failing the CI/CD pipeline when contract verification fails on Holesky testnet
- Now the pipeline will properly fail if Holesky contract verification fails

## Changes
- Updated `.github/workflows/deploy-testnet.yml:79` to remove the error suppression

## Test plan
- [ ] Verify that failed contract verification now fails the CI/CD pipeline
- [ ] Verify that successful verification still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)