### PR TITLE
Update Gnosis prize amount to 100 xDAI

### DIFF
--- a/gnosis-deploy.json
+++ b/gnosis-deploy.json
@@ -2,7 +2,7 @@
   "network": "gnosis",
   "chainId": 100,
   "prizeToken": "0xa555d5344f6fb6c65da19e403cb4c1ec4a1a5ee3",
-  "prizeAmount": "1000000000000000000",
+  "prizeAmount": "100000000000000000000",
   "projects": [
     {
       "title": "ReelDeal",


### PR DESCRIPTION
## Summary
- Increased prize amount from 1 xDAI (1000000000000000000 wei) to 100 xDAI (100000000000000000000 wei) in gnosis-deploy.json

## Test plan
- [ ] Verify gnosis-deploy.json has correct prizeAmount value
- [ ] Confirm deployment configuration is valid
- [ ] Test deployment process with updated prize amount

🤖 Generated with [Claude Code](https://claude.com/claude-code)